### PR TITLE
fix instructions for `pip install enum` in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Build the aws-dx-monitor package.  The script downloads the `Enum` backport for 
 
 ~~~sh
 $ cd aws-dx-monitor
-$ pip install enum34 -t enum
+$ pip install enum34 -t .
 $ python package.py
 ~~~
 


### PR DESCRIPTION
`pip install enum -t enum` creates a nested set of directories that

  *  don't get caught by the package script
  *  aren't importable if the package script is modified to include them

`pip install enum -t .` resolves this